### PR TITLE
Compatibility with secure Content Security Policy

### DIFF
--- a/lib/repost/extend_controller.rb
+++ b/lib/repost/extend_controller.rb
@@ -7,7 +7,10 @@ if defined?(Rails) && defined?(ActiveSupport)
         render html: Repost::Senpai.perform(
           url,
           params: params,
-          options: options.merge({authenticity_token: authenticity_token}.compact)
+          options: options.merge({
+            authenticity_token: authenticity_token,
+            autosubmit_nonce: content_security_policy_nonce,
+          }.compact)
         ).html_safe
       end
 

--- a/lib/repost/senpai.rb
+++ b/lib/repost/senpai.rb
@@ -12,6 +12,7 @@ module Repost
       @charset            = options.fetch(:charset, DEFAULT_CHARSET)
       @form_id            = options.fetch(:form_id, generated_form_id)
       @autosubmit         = options.fetch(:autosubmit, true)
+      @autosubmit_nonce   = options.fetch(:autosubmit_nonce, nil)
       @section_classes    = options.dig(:decor, :section, :classes)
       @section_html       = options.dig(:decor, :section, :html)
       @submit_classes     = options.dig(:decor, :submit, :classes)
@@ -31,7 +32,7 @@ module Repost
 
     attr_reader :url, :params, :options, :method, :form_id, :autosubmit,
                 :section_classes, :section_html, :submit_classes,
-                :submit_text, :authenticity_token, :charset
+                :submit_text, :authenticity_token, :charset, :autosubmit_nonce
 
     def form_head
       "<form id='#{form_id}' action='#{url}' method='#{method}' accept-charset='#{charset}'>"
@@ -81,7 +82,8 @@ module Repost
     end
 
     def auto_submit_script
-      "<script>
+      nonce_attr = %Q( nonce="#{autosubmit_nonce}") if autosubmit_nonce
+      "<script#{nonce_attr}>
         document.getElementById('#{form_id}').submit();
       </script>"
     end

--- a/spec/senpai_spec.rb
+++ b/spec/senpai_spec.rb
@@ -108,6 +108,30 @@ RSpec.describe Repost::Senpai do
         end
       end
 
+      describe 'autosubmit_nonce' do
+        context 'enabled' do
+          let(:options) do
+            {
+              autosubmit_nonce: 'anonce',
+            }
+          end
+
+          it 'includes nonce as script attr' do
+            expect(html).to include '<script nonce="anonce">'
+          end
+        end
+
+        context 'nil' do
+          let(:options) do
+            {}
+          end
+
+          it 'is bare script tag' do
+            expect(html).to include '<script>'
+          end
+        end
+      end
+
       describe 'decor' do
 
       end


### PR DESCRIPTION
To auto-submit the form, a bare script tag is generated. If a website has a content security policy, this is not allowed unless the website has enabled the "unsafe_inline" policy (which of course mostly defeats the purpose of a CSP).

This commit update the `Repost::Senpai` object allow a nonce to be configured to whitelist this inline script tag.

Since Rails supports a CSP out-of-the-box, the `repost` method has been configured to retrieve the request nonce and provide it to the `Repost::Senpai` object automatically.

If a nonce is desired outside of Rails (Sinatra, etc) this would have to be configured manually.