### PR TITLE
Use double splat kw args for ruby 3.x compatibility

### DIFF
--- a/lib/repost/action.rb
+++ b/lib/repost/action.rb
@@ -1,7 +1,7 @@
 module Repost
   class Action
-    def self.perform(*args)
-      action = new(*args)
+    def self.perform(*args, **kw_args)
+      action = new(*args, **kw_args)
       action.perform
     end
   end


### PR DESCRIPTION
This PR looks to bring ruby 3.x compatibility, by specifically separating the arguments from keyword arguments in `Repost::Action.perform`.

Current behaviour in rails 6.x app on ruby 3.x:

`redirect_post "/", options: { authenticity_token: :auto } # =>  wrong number of arguments (given 2, expected 1)`